### PR TITLE
2023 updates -- rekall removed, vol3 updates, python3 update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ There are three tools pre-installed and configured in the VM at the moment:
 
 * `vol`
 * `vol3`
-* `rekal` (upstream discontinued in October 2020)
 
 ### `vol`
 
@@ -73,23 +72,10 @@ This command runs the original, stable version of Volatility.
 
 ### `vol3`
 
-Volatility tool has a very unstable beta version, Volatility3. However, it
+Volatility tool has a stable new version, Volatility3. However, it
 processes the memory slightly differently and it could work on some memory
-images.
-
-*November 2020 update*: It seems that Volatility3 is undergoing another
-major rewrite, combined with changes on Microsoft side too (PDB debugging 
-symbols seem to be restructured a bit). That causes problems with Windows
-image analysis.
-
-### `rekal`
-
-Google Rekall framework doesn't seem to be supported much these days, but it
-still does its work. 
-
-*November 2020 update*: Google team officially discontinued the product
-and turned off some of the artifact repositories. Even though `rekal` command
-still kind of works, it may break any time.
+images. Also, the set of available plugins is still significantly
+smaller than for the previous version.
 
 ### Additional Tools
 

--- a/bashrc
+++ b/bashrc
@@ -4,7 +4,7 @@ RED='\033[0;37;41m'
 NC='\033[0m' # No Color
 
 export LC_ALL=en_US.UTF-8
-export PATH=$PATH:~/bin/:~/.venv/bin/
+export PATH=$PATH:~/bin/:~/.venv/bin/:~/.pyenv/bin/
 export VOLATILITY_PLUGINS=/home/vagrant/plugins/
 
 # Source some extra files
@@ -14,3 +14,6 @@ source /vagrant/bin/examples.sh
 # Install the bash-completions to make the VM easier to work with
 [[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
   . /usr/share/bash-completion/bash_completion
+
+# Initialize pyenv toolchain
+eval "$(pyenv init -)"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -2,11 +2,17 @@
 
 # Update the RPM repositories first, so that we have more packages available
 sudo yum install -y epel-release
-sudo rpm -Uvh http://repository.it4i.cz/mirrors/repoforge/redhat/el7/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el7.rf.x86_64.rpm
+#sudo rpm -Uvh http://repository.it4i.cz/mirrors/repoforge/redhat/el7/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el7.rf.x86_64.rpm
+sudo rpm -Uvh https://repository.it4i.cz/repoforge/redhat/el7/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el7.rf.x86_64.rpm
 sudo yum updateinfo
 
 # Install the things that are available as packages, and remove things that will be replaced by PIP
 sudo yum install -y vim wget python-pip gcc gcc-c++ python-devel readline-devel patch capstone git python3 python3-devel python-virtualenv radare2 strace
+# Additional requirements to build a pyenv tool
+sudo yum install -y make openssl-devel zlib-devel sqlite-devel bzip2-devel libffi-devel zlib
+sudo yum install -y openssl11-devel openssl11-libs openssl11 xz-devel
+
+# Other requirements for some of the tools below
 sudo yum remove -y PyYAML
 sudo yum install -y bash-completion bash-completion-extras
 sudo yum install -y python2-volatility unzip yara yara-devel python2-yara libjpeg-turbo-devel
@@ -15,6 +21,7 @@ sudo yum install -y git cabextract
 sudo yum install -y https://forensics.cert.org/cert-forensics-tools-release-el7.rpm
 sudo yum install -y foremost
 
+# Use the last pip available for python2.7
 sudo pip install --upgrade --no-cache-dir "pip < 21.0"
 sudo pip install wheel
 pip install powerline-status 
@@ -22,30 +29,34 @@ pip install powerline-status
 CFLAGS="-Wall -std=c99" pip install distorm3
 pip install construct==2.9.52 pefile==2019.4.18 pdbparse requests 
 
+# PyEnv setup, so that we can have multiple Python versions
+git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+
+# Install python-3.11 into this Centos7 box
+CPPFLAGS=-I/usr/include/openssl11 LDFLAGS=-L/usr/lib64/openssl11 pyenv install 3.11
+
 # Prepare the VirtualEnv for Google Rekall. This allows us to use the latest available/functional version,
 # and to use Python3
-virtualenv ~/.venv/ --python python3
 (
+  pyenv shell 3.11
+  python3 -m venv ~/.venv
+
   source ~/.venv/bin/activate
-  ln -s /usr/lib/libyara.so /home/vagrant/.venv/lib/libyara.so
-  pip install --upgrade pip
-  pip install setuptools pyasn1 pyyaml wheel yara-python
-  pip install construct==2.9.52 pdbparse
-  pip install future==0.16.0 pyaff4==0.26.post6
-  pip install rekall rekall-agent
+
+  pip install yara-python crypto
 
   git clone https://github.com/volatilityfoundation/volatility3 .volatility3
   cd .volatility3
   python setup.py build
   python setup.py install
+  # TODO: Check if we need to download symbols first
 
   pip install oletools peepdf
 
   deactivate
 )
-
-# Patch the discontinued Rekall agent to work a bit at least
-patch ~/.venv/lib/python3.6/site-packages/rekall_agent/agent.py /vagrant/provision/rekal_agent.patch
 
 # Prepare some further folder structure for our work
 mkdir ~/bin/
@@ -60,7 +71,6 @@ mkdir ~/yara/
 )
 
 # Final touches
-ln -s ~/.venv/bin/rekal ~/bin/rekal
 ln -s ~/.venv/bin/vol ~/bin/vol3
 ln -s ~/.venv/bin/peepdf ~/bin/peepdf
 


### PR DESCRIPTION
The list of changes:

- Google rekall project removed, as it's been long unsupported (resolves #2),
- python3 updated to 3.11, via pyenv (a requirement for latest vol3),
- current latest vol3 (2.4.1) seems to work, although some plugins are still missing.