### PR TITLE
Apple silicon PR to enable running on these hosts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:centos7
+
+RUN yum -y install sudo vim bzip2
+
+RUN adduser vagrant
+RUN usermod -a -G wheel vagrant
+RUN echo '%wheel ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+COPY bin /vagrant/bin
+COPY plugins /vagrant/plugins
+COPY signatures /vagrant/signatures
+COPY bashrc /vagrant/bashrc
+
+USER vagrant
+WORKDIR /home/vagrant
+
+COPY provision/provision.sh .
+RUN sudo chmod +x provision.sh
+RUN ./provision.sh
+
+USER root
+RUN rm -r provision.sh
+
+USER vagrant

--- a/Vagrantfile.m1mac
+++ b/Vagrantfile.m1mac
@@ -1,0 +1,42 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/centos7"
+
+  # Run this box in x86_64 mode, despite the performance hit
+  config.vm.provider "qemu" do |qe|
+    qe.arch = "x86_64"
+    qe.machine = "q35"
+    qe.cpu = "max"
+    qe.net_device = "virtio-net-pci"
+    qe.ssh_port = "50023"
+  end
+
+  # WARN: Not working pure arm64 setup. Perhaps for future runs of this course :)
+  # config.vm.box = "generic/centos7"
+  # config.vm.provider "qemu" do |qe|
+  #  qe.arch = "aarch64"
+  #  qe.ssh_port = "50023"
+  #  qe.machine = "virt,accel=hvf"
+  #  # qe.extra_qemu_args = ["-D", "./qemu-start-log.txt", "-boot", "order=d,menu=on"]
+  #  qe.cpu = "cortex-a72"
+  #end
+
+  config.vm.synced_folder ".", "/vagrant", type: "rsync",
+    rsync__exclude: [".git/", "images", "samples", "slides", "symbols"]
+
+  # View the documentation for the provider you are using for more
+  # information on available options.
+  config.vm.hostname = "memory-analysis"
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", privileged: false, path: "provision/provision.sh"
+end
+

--- a/doc/apple-silicon-startup.md
+++ b/doc/apple-silicon-startup.md
@@ -1,0 +1,62 @@
+# Running on Apple M1/M2/M3 hardware
+
+If you happen to be using Mac computers with Apple silicon processors,
+you need to use a slightly (or very, depends) process for provisioning
+a VM with the required tools.
+
+> :warn: Currently my setup only works with `x86_64` emulation.
+
+## Vagrant-based setup
+
+### Installing base tools
+
+In order to get all the things running, you need a few extra tools
+on your host:
+
+```bash
+brew install vagrant qemu
+#Due to dependency errors, we must install vbguest first..
+
+vagrant plugin install vagrant-vbguest
+vagrant plugin install vagrant-qemu
+```
+
+### Initial VM provisioning
+
+Then, if everything goes fine, things could be pretty straightforward.
+
+```bash
+VAGRANT_VAGRANTFILE=Vagrantfile.m1mac vagrant up
+```
+
+## Dockerized version
+
+Thanks to @adamivora and his effort, you can use another (easier) way of provisioning
+the necessary toolset on your host.
+
+### With Docker Compose
+
+You need the following software installed:
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+
+#### Option 1 - Build it yourself
+
+```bash
+docker compose build # takes ~20 minutes on a M1 Macbook Pro
+docker compose run memory-analysis /bin/bash
+```
+
+#### Option 2 - Use a pre-built image
+
+This is faster, but it means you trust me with the process of building the
+image and not including any malicious code.
+
+```bash
+docker compose -f docker-compose.prebuilt.yml run memory-analysis /bin/bash
+```
+
+### Resources
+
+- <https://gist.github.com/beauwilliams/69eabc42e540a309f53d55c4b8e6ffe3>
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  memory-analysis:
+    container_name: memory-analysis
+    # platform: linux/amd64
+    build: .
+    volumes:
+      - data:/opt/vagrant
+
+volumes:
+  data:


### PR DESCRIPTION
This PR enables provisioning Apple Mx VMs in two ways -- one with `vagrant`, the second one with Docker.